### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/lookup.js
+++ b/assets/js/lookup.js
@@ -14,9 +14,18 @@ function isValidDomain(domain) {
     return domainRegex.test(domain);
 }
 
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 function showMessage(message, type) {
     const messageDiv = document.getElementById('result');
-    messageDiv.innerHTML = message;
+    messageDiv.innerHTML = escapeHtml(message);
     messageDiv.className = 'alert ' + type;
 }
 
@@ -90,7 +99,7 @@ document.getElementById('lookup-form').addEventListener('submit', function (even
         if (!data) {
             return;
         }
-        let msg = `<h1>Domain ${data.domain} ${data.strict ? 'is on <a href="https://github.com/disposable/disposable?tab=readme-ov-file#strict-mode" target="_blank">strict mode list</a>' : 'is listed'}!</h1><p><h2>Sources:</h2><ul>`;
+        let msg = `<h1>Domain ${escapeHtml(data.domain)} ${data.strict ? 'is on <a href="https://github.com/disposable/disposable?tab=readme-ov-file#strict-mode" target="_blank">strict mode list</a>' : 'is listed'}!</h1><p><h2>Sources:</h2><ul>`;
         for (let i = 0; i < data.src.length; i++) {
             const entry = data.src[i],
                 external = entry['ext'];


### PR DESCRIPTION
Potential fix for [https://github.com/disposable/disposable-email-domains/security/code-scanning/2](https://github.com/disposable/disposable-email-domains/security/code-scanning/2)

To fix the problem, we need to ensure that any user input or untrusted data is properly escaped before being inserted into the DOM as HTML. This can be achieved by using a function to escape HTML special characters. We will create a utility function `escapeHtml` to escape the special characters in the `message` variable before assigning it to `innerHTML`.

We will modify the `showMessage` function to use this `escapeHtml` function. Additionally, we will ensure that any dynamic content in the `msg` variable is properly escaped before being concatenated into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
