### PR TITLE
Add aratrin.com to domains_strict.txt

### DIFF
--- a/domains_strict.txt
+++ b/domains_strict.txt
@@ -7082,6 +7082,7 @@ arapps.me
 arasempire.com
 arashkarimzadeh.com
 arasj.net
+aratrin.com
 aravites.com
 arbdigital.com
 arbvc.com


### PR DESCRIPTION
## Summary

- Adds `aratrin.com` to `domains_strict.txt` in correct alphabetical order (between `arasj.net` and `aravites.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)